### PR TITLE
Bugfix: Add missing preprocessor step

### DIFF
--- a/src/Streamnesia.Payloads/CommandPreprocessor.cs
+++ b/src/Streamnesia.Payloads/CommandPreprocessor.cs
@@ -16,6 +16,8 @@ public partial class CommandPreprocessor(Random random) : ICommandPreprocessor
         command = MinifyRegex().Replace(command, "").Trim();
         command = string.Format(command, GenerateGuids());
         command = command.Replace("<<RANDOM_MUSIC>>", GetRandomOggMusic());
+        command = command.Replace("{{", "{");
+        command = command.Replace("}}", "}");
 
         return command;
     }


### PR DESCRIPTION
## Changes

- The preprocessor now correctly replaces `{{` and `}}` with `{` and `}`.

## Motivation

Some payloads wouldn't execute with this.
