### PR TITLE
Add hosting on LAN + QR scan to open UI

### DIFF
--- a/src/Streamnesia.Client/Program.cs
+++ b/src/Streamnesia.Client/Program.cs
@@ -1,5 +1,9 @@
+using System.Net.Sockets;
+using System.Net;
 using Streamnesia.Client.Extensions;
 using Streamnesia.Client.Hubs;
+using QRCoder;
+using System.Net.NetworkInformation;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -31,9 +35,58 @@ app.MapControllerRoute(
     pattern: "{controller=Home}/{action=Index}/{id?}")
     .WithStaticAssets();
 
+app.Lifetime.ApplicationStarted.Register(() =>
+{
+    var localIp = GetLocalIPAddress();
+    var url = $"http://{localIp}:5000";
+
+    var qrGenerator = new QRCodeGenerator();
+    var qrCodeData = qrGenerator.CreateQrCode(url, QRCodeGenerator.ECCLevel.Q);
+    var asciiQr = new AsciiQRCode(qrCodeData);
+    string qrCodeAsAscii = asciiQr.GetGraphic(1);
+
+    Console.WriteLine("\nScan this QR code to open the app:");
+    Console.WriteLine(qrCodeAsAscii);
+    Console.WriteLine($"Or go to {url} on your phone/laptop on the same network");
+});
+
 // ensuring this gets activated on startup
 app.Services.GetRequiredService<AmnesiaClientEventDispatcher>();
 app.Services.GetRequiredService<TwitchPollDispatcher>();
 app.Services.GetRequiredService<TwitchClientEventDispatcher>();
 
 await app.RunAsync();
+
+static string GetLocalIPAddress()
+{
+    foreach (var ni in NetworkInterface.GetAllNetworkInterfaces())
+    {
+        if (ni.OperationalStatus != OperationalStatus.Up)
+            continue;
+
+        // Skip virtual or tunnel interfaces
+        if (ni.NetworkInterfaceType == NetworkInterfaceType.Loopback ||
+            ni.NetworkInterfaceType == NetworkInterfaceType.Tunnel)
+            continue;
+
+        var ipProps = ni.GetIPProperties();
+
+        foreach (var addr in ipProps.UnicastAddresses)
+        {
+            if (addr.Address.AddressFamily == AddressFamily.InterNetwork &&
+                !IPAddress.IsLoopback(addr.Address))
+            {
+                // Filter out VM-related or virtual adapters if needed
+                var ip = addr.Address.ToString();
+
+                // prioritize 192.168.x.x over 10.x or 172.x if multiple exist
+                if (ip.StartsWith("192.168.100."))
+                {
+                    return ip;
+                }
+            }
+        }
+    }
+
+    return "localhost";
+}

--- a/src/Streamnesia.Client/Streamnesia.Client.csproj
+++ b/src/Streamnesia.Client/Streamnesia.Client.csproj
@@ -15,6 +15,10 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="QRCoder" Version="1.6.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <ProjectReference Include="..\Streamnesia.Configuration\Streamnesia.Configuration.csproj" />
     <ProjectReference Include="..\Streamnesia.Core\Streamnesia.Core.csproj" />
     <ProjectReference Include="..\Streamnesia.Execution\Streamnesia.Execution.csproj" />

--- a/src/Streamnesia.Client/appsettings.json
+++ b/src/Streamnesia.Client/appsettings.json
@@ -2,6 +2,7 @@
     "Logging": {
         "LogLevel": {
             "Default": "Information",
+            "Microsoft.Hosting.Lifetime": "Warning",
             "Microsoft.AspNetCore": "Warning",
             "Streamnesia.Core.CommandQueue": "Information",
             "Streamnesia.Execution.AmnesiaClient": "Information"
@@ -16,5 +17,6 @@
         "BotName": "",
         "TwitchChannelName": ""
     },
-    "AllowedHosts": "*"
+    "AllowedHosts": "*",
+    "Urls": "http://0.0.0.0:5000"
 }


### PR DESCRIPTION
## Changes

- Set the environment to run the app open on LAN by default (Allowing the application will be necessary on launch)
- Generate a cool QR code to take users to the UI and motivate users to use a second device

## Motivation

- Using the UI on the same device is clunky with ALT + TABing around
- No need for users to know their IP, we educated-guess it on startup
- QR makes it extra easy to open
