### PR TITLE
Create development conductor

### DIFF
--- a/src/Streamnesia.Client/Controllers/HomeController.cs
+++ b/src/Streamnesia.Client/Controllers/HomeController.cs
@@ -2,6 +2,7 @@ using System.Diagnostics;
 using Microsoft.AspNetCore.Mvc;
 using Streamnesia.Client.Models;
 using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
 
 namespace Streamnesia.Client.Controllers;
 

--- a/src/Streamnesia.Client/Hubs/OverlayHub.cs
+++ b/src/Streamnesia.Client/Hubs/OverlayHub.cs
@@ -1,5 +1,5 @@
 ﻿using Microsoft.AspNetCore.SignalR;
-using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
 
 namespace Streamnesia.Client.Hubs;
 

--- a/src/Streamnesia.Client/Hubs/StatusHub.cs
+++ b/src/Streamnesia.Client/Hubs/StatusHub.cs
@@ -1,6 +1,7 @@
 ﻿using Microsoft.AspNetCore.SignalR;
 using Streamnesia.Client.Models;
 using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
 using Streamnesia.Core.Entities;
 
 namespace Streamnesia.Client.Hubs;

--- a/src/Streamnesia.Client/Hubs/TwitchPollDispatcher.cs
+++ b/src/Streamnesia.Client/Hubs/TwitchPollDispatcher.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.AspNetCore.SignalR;
 using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
 
 namespace Streamnesia.Client.Hubs;
 

--- a/src/Streamnesia.Core/Conductors/IDevelopmentConductor.cs
+++ b/src/Streamnesia.Core/Conductors/IDevelopmentConductor.cs
@@ -1,0 +1,8 @@
+﻿namespace Streamnesia.Core.Conductors;
+
+public interface IDevelopmentConductor
+{
+    event Func<string, CancellationToken, Task>? OnErrorAsync;
+
+    Task ExecuteAsync(CancellationToken cancellationToken = default);
+}

--- a/src/Streamnesia.Core/Conductors/ILocalPayloadConductor.cs
+++ b/src/Streamnesia.Core/Conductors/ILocalPayloadConductor.cs
@@ -1,6 +1,6 @@
 ﻿using FluentResults;
 
-namespace Streamnesia.Core;
+namespace Streamnesia.Core.Conductors;
 
 public interface ILocalPayloadConductor
 {

--- a/src/Streamnesia.Core/Conductors/ITwitchPollConductor.cs
+++ b/src/Streamnesia.Core/Conductors/ITwitchPollConductor.cs
@@ -1,9 +1,9 @@
 ﻿using FluentResults;
 using Streamnesia.Core.Entities;
 
-namespace Streamnesia.Core;
+namespace Streamnesia.Core.Conductors;
 
-public interface ITwitchPollConductor // NOTE(spelos): Maybe both conductors should share IConductor?
+public interface ITwitchPollConductor
 {
     bool IsRunning { get; }
 

--- a/src/Streamnesia.Execution/Conductors/DevelopmentConductor.cs
+++ b/src/Streamnesia.Execution/Conductors/DevelopmentConductor.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
+using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
+
+namespace Streamnesia.Execution.Conductors;
+
+internal class DevelopmentConductor(
+    IAmnesiaClient amnesiaClient,
+    ILogger<DevelopmentConductor> logger
+    ) : IDevelopmentConductor
+{
+    public event Func<string, CancellationToken, Task>? OnErrorAsync;
+
+    public async Task ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        logger.LogInformation("Development conductor executed");
+        
+        if (!amnesiaClient.IsConnected)
+        {
+            logger.LogDebug("Amnesia client not connected, attempting to connect...");
+            var result = await amnesiaClient.ConnectAsync(cancellationToken);
+
+            if (result.IsFailed)
+            {
+                var reason = string.Join(", ", result.Errors.Select(e => e.Message));
+                
+                if (OnErrorAsync is not null)
+                    await OnErrorAsync.Invoke(reason, cancellationToken);
+            }
+        }
+
+        logger.LogInformation("Development conductor completed");
+    }
+}

--- a/src/Streamnesia.Execution/Conductors/LocalPayloadConductor.cs
+++ b/src/Streamnesia.Execution/Conductors/LocalPayloadConductor.cs
@@ -9,8 +9,9 @@ using Streamnesia.Core.Configuration;
 using System.Collections;
 using Streamnesia.Core.Entities;
 using System.Collections.Generic;
+using Streamnesia.Core.Conductors;
 
-namespace Streamnesia.Execution;
+namespace Streamnesia.Execution.Conductors;
 
 public class LocalPayloadConductor(
     IAmnesiaClient amnesiaClient,

--- a/src/Streamnesia.Execution/Conductors/TwitchPollConductor.cs
+++ b/src/Streamnesia.Execution/Conductors/TwitchPollConductor.cs
@@ -6,9 +6,10 @@ using System.Threading.Tasks;
 using FluentResults;
 using Microsoft.Extensions.Logging;
 using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
 using Streamnesia.Core.Entities;
 
-namespace Streamnesia.Execution;
+namespace Streamnesia.Execution.Conductors;
 
 public class TwitchPollConductor(
     IAmnesiaClient amnesiaClient,

--- a/src/Streamnesia.Execution/ServiceCollectionExtensions.cs
+++ b/src/Streamnesia.Execution/ServiceCollectionExtensions.cs
@@ -2,6 +2,8 @@
 using System.Net.Sockets;
 using Microsoft.Extensions.DependencyInjection;
 using Streamnesia.Core;
+using Streamnesia.Core.Conductors;
+using Streamnesia.Execution.Conductors;
 
 namespace Streamnesia.Execution;
 


### PR DESCRIPTION
## Changes

Added the implementation for DevelopmentConductor as well as moved conductors into their own namespace for better organization.

Closes #81 