### PR TITLE
refactor(poll): use in-place shuffle and prevent payload repetition

### DIFF
--- a/src/Streamnesia.Execution/Conductors/TwitchPollConductor.cs
+++ b/src/Streamnesia.Execution/Conductors/TwitchPollConductor.cs
@@ -99,6 +99,8 @@ public class TwitchPollConductor(
 
     public Result<IReadOnlyCollection<ParsedPayload>> BeginPollRound()
     {
+        logger.LogInformation("Starting a new round of voting");
+
         if (_currentPayloadIdx + 4 > _allPayloads.Count)
         {
             _currentPayloadIdx = 0;


### PR DESCRIPTION
# Pull Request

Thank you for contributing to Streamnesia! 🚀

## Changes

- Replaced payload selection via `OrderBy(Guid.NewGuid()).Take(4)` with in-place shuffle and Random.Shared
- Ensures every payload is used exactly once per cycle before reshuffling
- Reduces allocations (skips queue creation)

## Motivation

Resolves #67 

This change moves the shuffle to the beginning of each cycle.  
We iterate through the shuffled list in chunks of 4.  
Once we reach the end, we reshuffle and repeat the process.

This ensures better randomness, no repeats until all options are shown, and avoids unnecessary allocations.

## Checklist

- [x] I tested the changes
- [x] I documented new code or behaviors
- [x] I kept changes small and focused